### PR TITLE
removing this preference will fix push error

### DIFF
--- a/force-app/main/default/settings/OrgPreference.settings-meta.xml
+++ b/force-app/main/default/settings/OrgPreference.settings-meta.xml
@@ -105,10 +105,6 @@
         <settingValue>false</settingValue>
     </preferences>
     <preferences>
-        <settingName>ReportDataCaptureEnabled</settingName>
-        <settingValue>false</settingValue>
-    </preferences>
-    <preferences>
         <settingName>S1EncryptedStoragePref2</settingName>
         <settingValue>true</settingValue>
     </preferences>


### PR DESCRIPTION
Executing this line 
```
sfdx force:source:push -f
```
Will fail and give error ID `85919423-49858 (412474181)`.  Apparently this is a known issue due to `ReportDataCaptureEnabled` being deprecated in the Summer `19 release, and the solution I propose is outlined in this report:
https://success.salesforce.com/issues_view?id=a1p3A000001SGuRQAW&title=metadata-api-deployments-are-failing-after-summer-19-updgrade